### PR TITLE
Switch to outgoing physical stage to make sure all headers are present

### DIFF
--- a/src/NServiceBus.Serilog/MessageAudit/LogOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Serilog/MessageAudit/LogOutgoingMessageBehavior.cs
@@ -9,7 +9,7 @@ using Serilog.Events;
 using Serilog.Parsing;
 
 class LogOutgoingMessageBehavior :
-    Behavior<IOutgoingLogicalMessageContext>
+    Behavior<IOutgoingPhysicalMessageContext>
 {
     MessageTemplate messageTemplate;
 
@@ -19,14 +19,14 @@ class LogOutgoingMessageBehavior :
         messageTemplate = templateParser.Parse("Sent message {OutgoingMessageType} {OutgoingMessageId}.");
     }
 
-    public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+    public override Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
     {
-        var message = context.Message.Instance;
+        var message = context.Extensions.Get<OutgoingLogicalMessage>().Instance;
         LogMessage(context, context.Logger(), message);
         return next();
     }
 
-    void LogMessage(IOutgoingLogicalMessageContext context, ILogger forContext, object message)
+    void LogMessage(IOutgoingPhysicalMessageContext context, ILogger forContext, object message)
     {
         var properties = new List<LogEventProperty>();
 
@@ -55,8 +55,6 @@ class LogOutgoingMessageBehavior :
                 behavior: typeof(LogOutgoingMessageBehavior),
                 description: "Logs outgoing messages")
         {
-            InsertAfterIfExists("ApplyReplyToAddressBehavior");
-            InsertAfter("AddHostInfoHeaders");
         }
     }
 }

--- a/src/NServiceBus.Serilog/NServiceBusExtensions.cs
+++ b/src/NServiceBus.Serilog/NServiceBusExtensions.cs
@@ -59,7 +59,7 @@ static class NServiceBusExtensions
 
     static Dictionary<string, string> emptyDictionary = new Dictionary<string, string>();
 
-    public static List<string> UnicastAddresses(this IOutgoingLogicalMessageContext context)
+    public static List<string> UnicastAddresses(this IOutgoingPhysicalMessageContext context)
     {
         return context.RoutingStrategies
             .OfType<UnicastRoutingStrategy>()


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus/issues/5635

@andreasohlund and I discussed this today and think it is a better approach to attach to the next stage after the logical stage to make sure you don't need ordering