### PR TITLE
Push the correlation properties onto Serilog's ambient LogContext

### DIFF
--- a/src/NServiceBus.Community.Serilog/LogInjection/IncomingPhysicalBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/LogInjection/IncomingPhysicalBehavior.cs
@@ -62,19 +62,41 @@
         context.Extensions.Set(exceptionLogState);
         context.Extensions.Set(loggerForContext);
 
-        try
+        // Also push the correlation properties onto Serilog's ambient LogContext so that
+        // events emitted via the static Log.Logger during message processing — including
+        // from third-party callbacks that have no access to context.Logger() — carry the
+        // same IncomingMessageId/CorrelationId/ConversationId as this library's own
+        // tracing events. Requires Enrich.FromLogContext() on the consumer's logger; if
+        // absent the push is a no-op.
+        var logContextEnrichers = new List<ILogEventEnricher>
         {
-            await next();
+            new PropertyEnricher("IncomingMessageId", context.MessageId)
+        };
+        if (correlationId != null)
+        {
+            logContextEnrichers.Add(new PropertyEnricher("CorrelationId", correlationId));
         }
-        catch (Exception exception)
+        if (conversationId != null)
         {
-            var data = exception.Data;
-            if (!data.Contains("ExceptionLogState"))
-            {
-                data.Add("ExceptionLogState", exceptionLogState);
-            }
+            logContextEnrichers.Add(new PropertyEnricher("ConversationId", conversationId));
+        }
 
-            throw;
+        using (LogContext.Push(logContextEnrichers.ToArray()))
+        {
+            try
+            {
+                await next();
+            }
+            catch (Exception exception)
+            {
+                var data = exception.Data;
+                if (!data.Contains("ExceptionLogState"))
+                {
+                    data.Add("ExceptionLogState", exceptionLogState);
+                }
+
+                throw;
+            }
         }
     }
 }

--- a/src/Tests/IncomingPhysicalBehaviorLogContextTests.cs
+++ b/src/Tests/IncomingPhysicalBehaviorLogContextTests.cs
@@ -1,0 +1,76 @@
+[NotInParallel]
+public class IncomingPhysicalBehaviorLogContextTests
+{
+    [Test]
+    public async Task PushesCorrelationOntoLogContextForStaticLogCalls()
+    {
+        var events = new List<LogEvent>();
+        var capturingLogger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new EventSink(events.Add))
+            .CreateLogger();
+
+        var previousLog = Log.Logger;
+        Log.Logger = capturingLogger;
+        try
+        {
+            var logBuilder = new LogBuilder(new FakeLogger(), "endpoint");
+            var behavior = new IncomingPhysicalBehavior(logBuilder, "endpoint");
+            var context = new RecordingIncomingPhysicalMessageContext(
+                headers:
+                [
+                    new(Headers.CorrelationId, "the-correlation-id"),
+                    new(Headers.ConversationId, "the-conversation-id")
+                ]);
+
+            await behavior.Invoke(context, () =>
+            {
+                Log.Information("inside handler");
+                return Task.CompletedTask;
+            });
+
+            var captured = events.Single(_ => _.MessageTemplate.Text == "inside handler");
+            await Assert.That(((ScalarValue) captured.Properties["IncomingMessageId"]).Value).IsEqualTo(context.MessageId);
+            await Assert.That(((ScalarValue) captured.Properties["CorrelationId"]).Value).IsEqualTo("the-correlation-id");
+            await Assert.That(((ScalarValue) captured.Properties["ConversationId"]).Value).IsEqualTo("the-conversation-id");
+        }
+        finally
+        {
+            Log.Logger = previousLog;
+            capturingLogger.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task LogContextScopeIsReleasedAfterNext()
+    {
+        var events = new List<LogEvent>();
+        var capturingLogger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new EventSink(events.Add))
+            .CreateLogger();
+
+        var previousLog = Log.Logger;
+        Log.Logger = capturingLogger;
+        try
+        {
+            var logBuilder = new LogBuilder(new FakeLogger(), "endpoint");
+            var behavior = new IncomingPhysicalBehavior(logBuilder, "endpoint");
+            var context = new RecordingIncomingPhysicalMessageContext();
+
+            await behavior.Invoke(context, () => Task.CompletedTask);
+
+            Log.Information("outside handler");
+
+            var captured = events.Single(_ => _.MessageTemplate.Text == "outside handler");
+            await Assert.That(captured.Properties.ContainsKey("IncomingMessageId")).IsFalse();
+            await Assert.That(captured.Properties.ContainsKey("CorrelationId")).IsFalse();
+            await Assert.That(captured.Properties.ContainsKey("ConversationId")).IsFalse();
+        }
+        finally
+        {
+            Log.Logger = previousLog;
+            capturingLogger.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Static Serilog.Log.Logger calls made during message handling — including from third-party callbacks that have no access to context.Logger()  so they miss ou ton property enrichment of message id, correlation id etc.
 

#### The solution

Change  IncomingPhysicalBehavior to also push the same three properties onto Serilog's ambient LogContext for the duration of await next(). 

I've add two tests — one asserts that a static Log.Information(...) call inside next() get enriched and the other asserts the scope is released after next() returns.

