### PR TITLE
Gate LogOutgoingBehavior on Information level

### DIFF
--- a/src/NServiceBus.Community.Serilog/MessageAudit/LogOutgoingBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/MessageAudit/LogOutgoingBehavior.cs
@@ -15,14 +15,19 @@
 
     public override Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
     {
-        var message = context.Extensions
-            .Get<OutgoingLogicalMessage>()
-            .Instance;
-        LogMessage(context, context.Logger(), message);
+        var logger = context.Logger();
+        if (logger.IsEnabled(LogEventLevel.Information))
+        {
+            var message = context.Extensions
+                .Get<OutgoingLogicalMessage>()
+                .Instance;
+            LogInfoMessage(context, logger, message);
+        }
+
         return next();
     }
 
-    void LogMessage(IOutgoingPhysicalMessageContext context, ILogger logger, object message)
+    void LogInfoMessage(IOutgoingPhysicalMessageContext context, ILogger logger, object message)
     {
         var properties = new List<LogEventProperty>();
 


### PR DESCRIPTION
  CaptureSagaStateBehavior already short-circuits when Information is
  disabled; LogOutgoingBehavior built the full LogEvent (allocating
  properties, destructuring the outgoing message via BindProperty,
  walking headers) and let Serilog drop it at Write time. Check
  IsEnabled up front instead.

  Matches the gating pattern across the three audit behaviors and
  avoids the destructuring side-effects on filtered events.
