### PR TITLE
audit on failure, level gate, Stopwatch timing, saga state via Extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,7 +243,7 @@ When a pipeline exception is logged, it will be enriched with the following prop
 HeaderAppender.Exclude("MyCustomHeader");
 HeaderAppender.Exclude("HeaderA", "HeaderB", "HeaderC");
 ```
-<sup><a href='/src/Tests/HeaderAppenderTests.cs#L12-L15' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExcludeHeaders' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/HeaderAppenderTests.cs#L10-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExcludeHeaders' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `Exclude` must be called during application startup, **before** `LogManager.Use<SerilogFactory>()`. Once `SerilogFactory` has been constructed the exclude set is frozen and any subsequent call to `Exclude` throws `InvalidOperationException`. This makes the set effectively immutable for the lifetime of the endpoint and eliminates any race between configuration and the running pipeline.
@@ -372,7 +372,7 @@ serilogTracing.EnableSagaTracing();
           Originator: SerilogTestsStartSaga,
           OriginalMessageId: Guid_1
         },
-        FinishTime: DateTimeOffset_1,
+        FinishTime: {Scrubbed},
         IncomingMessageId: Guid_1,
         IncomingMessageType: StartSaga,
         IncomingMessageTypeLong: StartSaga, Tests, Version=0.0.0.0,
@@ -382,7 +382,7 @@ serilogTracing.EnableSagaTracing();
           OriginatingMachine: TheMachineName,
           OriginatingEndpoint: SerilogTestsStartSaga,
           MessageType: StartSaga,
-          TimeSent: DateTimeOffset_2,
+          TimeSent: DateTimeOffset_1,
           Intent: Send
         },
         IsCompleted: false,
@@ -401,7 +401,7 @@ serilogTracing.EnableSagaTracing();
         SagaId: Guid_5,
         SagaType: TheSaga,
         SourceContext: StartSaga,
-        StartTime: DateTimeOffset_3
+        StartTime: {Scrubbed}
       }
     },
     {
@@ -411,7 +411,7 @@ serilogTracing.EnableSagaTracing();
         ConversationId: Guid_2,
         CorrelationId: Guid_1,
         ElapsedTime: {Scrubbed},
-        FinishTime: DateTimeOffset_4,
+        FinishTime: {Scrubbed},
         IncomingMessage: {
           TypeTag: StartSaga,
           Property: TheProperty
@@ -431,8 +431,8 @@ serilogTracing.EnableSagaTracing();
         ReplyToAddress: SerilogTestsStartSaga,
         Serilog.SagaStateChange: {Scrubbed},
         SourceContext: StartSaga,
-        StartTime: DateTimeOffset_5,
-        TimeSent: DateTimeOffset_2,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     },
@@ -553,9 +553,11 @@ serilogTracing.EnableMessageTracing();
 class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
     FeatureStartupTask
 {
+    readonly ILogger startupLogger = logger.ForContext<StartupDiagnostics>();
+
     protected override Task OnStart(IMessageSession session, Cancel cancel = default)
     {
-        var properties = BuildProperties(settings, logger);
+        var properties = BuildProperties(settings, startupLogger);
 
         var templateParser = new MessageTemplateParser();
         var messageTemplate = templateParser.Parse("DiagnosticEntries");
@@ -565,7 +567,7 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
             exception: null,
             messageTemplate: messageTemplate,
             properties: properties);
-        logger.Write(logEvent);
+        startupLogger.Write(logEvent);
         return Task.CompletedTask;
     }
 
@@ -601,8 +603,6 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
 
     protected override Task OnStop(IMessageSession session, Cancel cancel = default) =>
         Task.CompletedTask;
-
-    ILogger logger = logger.ForContext<StartupDiagnostics>();
 }
 ```
 <sup><a href='/src/NServiceBus.Community.Serilog/StartupDiagnostics/WriteStartupDiagnostics.cs#L1-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-WriteStartupDiagnostics' title='Start of snippet'>anchor</a></sup>

--- a/src/NServiceBus.Community.Serilog/MessageAudit/LogIncomingBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/MessageAudit/LogIncomingBehavior.cs
@@ -4,7 +4,7 @@
     ConvertHeader convertHeader;
     static MessageTemplate messageTemplate;
 
-    LogIncomingBehavior(ConvertHeader convertHeader) =>
+    internal LogIncomingBehavior(ConvertHeader convertHeader) =>
         this.convertHeader = convertHeader;
 
     static LogIncomingBehavior()
@@ -32,24 +32,46 @@
 
     public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
     {
-        var message = context.Message;
         var logger = context.Logger();
-        var startTime = DateTimeOffset.Now;
-        await next();
-        var finishTime = DateTimeOffset.Now;
-        var properties = new List<LogEventProperty>
+        // Must match the level used by SerilogExtensions.WriteInfo below.
+        if (!logger.IsEnabled(LogEventLevel.Information))
         {
-            new("StartTime", new ScalarValue(startTime.ToLogString())),
-            new("FinishTime", new ScalarValue(finishTime.ToLogString())),
-            new("ElapsedTime", new ScalarValue((finishTime - startTime).TotalSeconds))
-        };
-
-        if (logger.BindProperty("IncomingMessage", message.Instance, out var property))
-        {
-            properties.Add(property);
+            await next();
+            return;
         }
 
-        properties.AddRange(HeaderAppender.BuildHeaders(context.Headers, convertHeader));
-        logger.WriteInfo(messageTemplate, properties);
+        var message = context.Message;
+        var sagaStateChanges = new SagaStateChangeRecorder();
+        context.Extensions.Set(sagaStateChanges);
+        var startTime = DateTimeOffset.Now;
+        var startTimestamp = Stopwatch.GetTimestamp();
+        try
+        {
+            await next();
+        }
+        finally
+        {
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            var finishTime = startTime + elapsed;
+            var properties = new List<LogEventProperty>
+            {
+                new("StartTime", new ScalarValue(startTime.ToLogString())),
+                new("FinishTime", new ScalarValue(finishTime.ToLogString())),
+                new("ElapsedTime", new ScalarValue(elapsed.TotalSeconds))
+            };
+
+            if (logger.BindProperty("IncomingMessage", message.Instance, out var property))
+            {
+                properties.Add(property);
+            }
+
+            if (sagaStateChanges.Value.Length > 0)
+            {
+                properties.Add(new("Serilog.SagaStateChange", new ScalarValue(sagaStateChanges.Value)));
+            }
+
+            properties.AddRange(HeaderAppender.BuildHeaders(context.Headers, convertHeader));
+            logger.WriteInfo(messageTemplate, properties);
+        }
     }
 }

--- a/src/NServiceBus.Community.Serilog/SagaAudit/CaptureSagaStateBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/SagaAudit/CaptureSagaStateBehavior.cs
@@ -19,6 +19,7 @@
         }
 
         var logger = context.Logger();
+        // Must match the level used by SerilogExtensions.WriteInfo below.
         if (!logger.IsEnabled(LogEventLevel.Information))
         {
             await next();
@@ -28,10 +29,12 @@
         var sagaAudit = new SagaUpdatedMessage();
         context.Extensions.Set(sagaAudit);
         var startTime = DateTimeOffset.Now;
+        var startTimestamp = Stopwatch.GetTimestamp();
 
         await next();
 
-        var finishTime = DateTimeOffset.Now;
+        var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+        var finishTime = startTime + elapsed;
 
         if (!context.Extensions.TryGet(out ActiveSagaInstance? activeSagaInstance))
         {
@@ -65,7 +68,7 @@
             new("SagaId", new ScalarValue(sagaId)),
             new("StartTime", new ScalarValue(startTime)),
             new("FinishTime", new ScalarValue(finishTime)),
-            new("ElapsedTime", new ScalarValue((finishTime - startTime).TotalSeconds)),
+            new("ElapsedTime", new ScalarValue(elapsed.TotalSeconds)),
             new("IsCompleted", new ScalarValue(isCompleted)),
             new("IsNew", new ScalarValue(isNew))
         };
@@ -137,11 +140,6 @@
 
     static void AssignSagaStateChangeCausedByMessage(IInvokeHandlerContext context, bool isNew, bool isCompleted, Guid sagaId)
     {
-        if (!context.Headers.TryGetValue("NServiceBus.Serilog.SagaStateChange", out var sagaStateChange))
-        {
-            sagaStateChange = string.Empty;
-        }
-
         var stateChange = "Updated";
         if (isNew)
         {
@@ -153,14 +151,13 @@
             stateChange = "Completed";
         }
 
-        if (!string.IsNullOrEmpty(sagaStateChange))
+        if (!context.Extensions.TryGet<SagaStateChangeRecorder>(out var recorder))
         {
-            sagaStateChange += ';';
+            recorder = new();
+            context.Extensions.Set(recorder);
         }
 
-        sagaStateChange += $"{sagaId}:{stateChange}";
-
-        context.Headers["NServiceBus.Serilog.SagaStateChange"] = sagaStateChange;
+        recorder.Record(sagaId, stateChange);
     }
 
     public class Registration :

--- a/src/NServiceBus.Community.Serilog/SagaAudit/SagaStateChangeRecorder.cs
+++ b/src/NServiceBus.Community.Serilog/SagaAudit/SagaStateChangeRecorder.cs
@@ -1,0 +1,16 @@
+class SagaStateChangeRecorder
+{
+    string value = string.Empty;
+
+    public void Record(Guid sagaId, string stateChange)
+    {
+        if (value.Length > 0)
+        {
+            value += ';';
+        }
+
+        value += $"{sagaId}:{stateChange}";
+    }
+
+    public string Value => value;
+}

--- a/src/Tests/IntegrationTests.BehaviorThatThrows.verified.txt
+++ b/src/Tests/IntegrationTests.BehaviorThatThrows.verified.txt
@@ -33,6 +33,37 @@
       }
     },
     {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartBehaviorThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartBehaviorThatThrows,
+        IncomingMessageTypeLong: StartBehaviorThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: False,
+        OriginatingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        ReplyToAddress: SerilogTestsStartBehaviorThatThrows,
+        SourceContext: StartBehaviorThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
       Information: Immediate Retry is going to retry message 'Guid_1' because of an exception:,
       Properties: {
         ContentType: application/json,
@@ -70,6 +101,37 @@
         ProcessingEndpoint: SerilogTestsStartBehaviorThatThrows,
         ReplyToAddress: SerilogTestsStartBehaviorThatThrows,
         SourceContext: NServiceBus.ImmediateRetry,
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartBehaviorThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartBehaviorThatThrows,
+        IncomingMessageTypeLong: StartBehaviorThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: False,
+        OriginatingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        ReplyToAddress: SerilogTestsStartBehaviorThatThrows,
+        SourceContext: StartBehaviorThatThrows,
+        StartTime: {Scrubbed},
         TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
@@ -117,6 +179,40 @@
       }
     },
     {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        DeliverAt: DateTimeOffset_2,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartBehaviorThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartBehaviorThatThrows,
+        IncomingMessageTypeLong: StartBehaviorThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: True,
+        OriginatingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        ReplyToAddress: SerilogTestsStartBehaviorThatThrows,
+        Retries: 1,
+        Retries.Timestamp: DateTimeOffset_3,
+        SourceContext: StartBehaviorThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
       Information: Immediate Retry is going to retry message 'Guid_1' because of an exception:,
       Properties: {
         ContentType: application/json,
@@ -157,6 +253,40 @@
         Retries: 1,
         Retries.Timestamp: DateTimeOffset_3,
         SourceContext: NServiceBus.ImmediateRetry,
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        DeliverAt: DateTimeOffset_2,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartBehaviorThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartBehaviorThatThrows,
+        IncomingMessageTypeLong: StartBehaviorThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: True,
+        OriginatingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartBehaviorThatThrows,
+        ReplyToAddress: SerilogTestsStartBehaviorThatThrows,
+        Retries: 1,
+        Retries.Timestamp: DateTimeOffset_3,
+        SourceContext: StartBehaviorThatThrows,
+        StartTime: {Scrubbed},
         TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }

--- a/src/Tests/IntegrationTests.HandlerThatThrows.verified.txt
+++ b/src/Tests/IntegrationTests.HandlerThatThrows.verified.txt
@@ -33,6 +33,37 @@
       }
     },
     {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartHandlerThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartHandlerThatThrows,
+        IncomingMessageTypeLong: StartHandlerThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: False,
+        OriginatingEndpoint: SerilogTestsStartHandlerThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
+        ReplyToAddress: SerilogTestsStartHandlerThatThrows,
+        SourceContext: StartHandlerThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
       Information: Immediate Retry is going to retry message 'Guid_1' because of an exception:,
       Properties: {
         ContentType: application/json,
@@ -43,8 +74,8 @@
           Data: {
             Message type: StartHandlerThatThrows,
             Handler type: TheHandlerThatThrows,
-            Handler start time: DateTimeOffset_1,
-            Handler failure time: DateTimeOffset_2,
+            Handler start time: {Scrubbed},
+            Handler failure time: {Scrubbed},
             Handler canceled: false,
             ExceptionLogState: {
               TypeTag: ExceptionLogState
@@ -58,8 +89,8 @@
           Source: Tests,
           TargetSite: {Scrubbed}
         },
-        HandlerFailureTime: DateTimeOffset_3,
-        HandlerStartTime: DateTimeOffset_4,
+        HandlerFailureTime: {Scrubbed},
+        HandlerStartTime: {Scrubbed},
         HandlerType: TheHandlerThatThrows,
         IncomingMessage: {
           TypeTag: StartHandlerThatThrows,
@@ -79,7 +110,38 @@
         ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
         ReplyToAddress: SerilogTestsStartHandlerThatThrows,
         SourceContext: NServiceBus.ImmediateRetry,
-        TimeSent: DateTimeOffset_5,
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartHandlerThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartHandlerThatThrows,
+        IncomingMessageTypeLong: StartHandlerThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: False,
+        OriginatingEndpoint: SerilogTestsStartHandlerThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
+        ReplyToAddress: SerilogTestsStartHandlerThatThrows,
+        SourceContext: StartHandlerThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     },
@@ -94,8 +156,8 @@
           Data: {
             Message type: StartHandlerThatThrows,
             Handler type: TheHandlerThatThrows,
-            Handler start time: DateTimeOffset_6,
-            Handler failure time: DateTimeOffset_7,
+            Handler start time: {Scrubbed},
+            Handler failure time: {Scrubbed},
             Handler canceled: false,
             ExceptionLogState: {
               TypeTag: ExceptionLogState
@@ -109,8 +171,8 @@
           Source: Tests,
           TargetSite: {Scrubbed}
         },
-        HandlerFailureTime: DateTimeOffset_8,
-        HandlerStartTime: DateTimeOffset_9,
+        HandlerFailureTime: {Scrubbed},
+        HandlerStartTime: {Scrubbed},
         HandlerType: TheHandlerThatThrows,
         IncomingMessage: {
           TypeTag: StartHandlerThatThrows,
@@ -130,7 +192,41 @@
         ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
         ReplyToAddress: SerilogTestsStartHandlerThatThrows,
         SourceContext: NServiceBus.DelayedRetry,
-        TimeSent: DateTimeOffset_5,
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        DeliverAt: DateTimeOffset_2,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartHandlerThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartHandlerThatThrows,
+        IncomingMessageTypeLong: StartHandlerThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: True,
+        OriginatingEndpoint: SerilogTestsStartHandlerThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
+        ReplyToAddress: SerilogTestsStartHandlerThatThrows,
+        Retries: 1,
+        Retries.Timestamp: DateTimeOffset_3,
+        SourceContext: StartHandlerThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     },
@@ -140,14 +236,14 @@
         ContentType: application/json,
         ConversationId: Guid_2,
         CorrelationId: Guid_1,
-        DeliverAt: DateTimeOffset_10,
+        DeliverAt: DateTimeOffset_2,
         ExceptionDetail: {
           Type: System.Exception,
           Data: {
             Message type: StartHandlerThatThrows,
             Handler type: TheHandlerThatThrows,
-            Handler start time: DateTimeOffset_11,
-            Handler failure time: DateTimeOffset_12,
+            Handler start time: {Scrubbed},
+            Handler failure time: {Scrubbed},
             Handler canceled: false,
             ExceptionLogState: {
               TypeTag: ExceptionLogState
@@ -161,8 +257,8 @@
           Source: Tests,
           TargetSite: {Scrubbed}
         },
-        HandlerFailureTime: DateTimeOffset_13,
-        HandlerStartTime: DateTimeOffset_14,
+        HandlerFailureTime: {Scrubbed},
+        HandlerStartTime: {Scrubbed},
         HandlerType: TheHandlerThatThrows,
         IncomingMessage: {
           TypeTag: StartHandlerThatThrows,
@@ -182,9 +278,43 @@
         ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
         ReplyToAddress: SerilogTestsStartHandlerThatThrows,
         Retries: 1,
-        Retries.Timestamp: DateTimeOffset_15,
+        Retries.Timestamp: DateTimeOffset_3,
         SourceContext: NServiceBus.ImmediateRetry,
-        TimeSent: DateTimeOffset_5,
+        TimeSent: DateTimeOffset_1,
+        TraceParent: {Scrubbed}
+      }
+    },
+    {
+      Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+      Properties: {
+        ContentType: application/json,
+        ConversationId: Guid_2,
+        CorrelationId: Guid_1,
+        DeliverAt: DateTimeOffset_2,
+        ElapsedTime: {Scrubbed},
+        FinishTime: {Scrubbed},
+        IncomingMessage: {
+          TypeTag: StartHandlerThatThrows,
+          Property: TheProperty
+        },
+        IncomingMessageId: Guid_1,
+        IncomingMessageType: StartHandlerThatThrows,
+        IncomingMessageTypeLong: StartHandlerThatThrows, Tests, Version=0.0.0.0,
+        MessageIntent: Send,
+        OpenTelemetry.StartNewTrace: True,
+        OriginatingEndpoint: SerilogTestsStartHandlerThatThrows,
+        OriginatingHostId: Guid_3,
+        OriginatingMachine: TheMachineName,
+        OtherHeaders: {
+          baggage: {Scrubbed}
+        },
+        ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
+        ReplyToAddress: SerilogTestsStartHandlerThatThrows,
+        Retries: 1,
+        Retries.Timestamp: DateTimeOffset_3,
+        SourceContext: StartHandlerThatThrows,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     },
@@ -194,14 +324,14 @@
         ContentType: application/json,
         ConversationId: Guid_2,
         CorrelationId: Guid_1,
-        DeliverAt: DateTimeOffset_10,
+        DeliverAt: DateTimeOffset_2,
         ExceptionDetail: {
           Type: System.Exception,
           Data: {
             Message type: StartHandlerThatThrows,
             Handler type: TheHandlerThatThrows,
-            Handler start time: DateTimeOffset_16,
-            Handler failure time: DateTimeOffset_17,
+            Handler start time: {Scrubbed},
+            Handler failure time: {Scrubbed},
             Handler canceled: false,
             ExceptionLogState: {
               TypeTag: ExceptionLogState
@@ -215,8 +345,8 @@
           Source: Tests,
           TargetSite: {Scrubbed}
         },
-        HandlerFailureTime: DateTimeOffset_18,
-        HandlerStartTime: DateTimeOffset_19,
+        HandlerFailureTime: {Scrubbed},
+        HandlerStartTime: {Scrubbed},
         HandlerType: TheHandlerThatThrows,
         IncomingMessage: {
           TypeTag: StartHandlerThatThrows,
@@ -236,9 +366,9 @@
         ProcessingEndpoint: SerilogTestsStartHandlerThatThrows,
         ReplyToAddress: SerilogTestsStartHandlerThatThrows,
         Retries: 1,
-        Retries.Timestamp: DateTimeOffset_15,
+        Retries.Timestamp: DateTimeOffset_3,
         SourceContext: NServiceBus.MoveToError,
-        TimeSent: DateTimeOffset_5,
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     }

--- a/src/Tests/IntegrationTests.Saga.verified.txt
+++ b/src/Tests/IntegrationTests.Saga.verified.txt
@@ -104,7 +104,7 @@
           Originator: SerilogTestsStartSaga,
           OriginalMessageId: Guid_1
         },
-        FinishTime: DateTimeOffset_1,
+        FinishTime: {Scrubbed},
         IncomingMessageId: Guid_1,
         IncomingMessageType: StartSaga,
         IncomingMessageTypeLong: StartSaga, Tests, Version=0.0.0.0,
@@ -114,7 +114,7 @@
           OriginatingMachine: TheMachineName,
           OriginatingEndpoint: SerilogTestsStartSaga,
           MessageType: StartSaga,
-          TimeSent: DateTimeOffset_2,
+          TimeSent: DateTimeOffset_1,
           Intent: Send
         },
         IsCompleted: false,
@@ -133,7 +133,7 @@
         SagaId: Guid_5,
         SagaType: TheSaga,
         SourceContext: StartSaga,
-        StartTime: DateTimeOffset_3
+        StartTime: {Scrubbed}
       }
     },
     {
@@ -143,7 +143,7 @@
         ConversationId: Guid_2,
         CorrelationId: Guid_1,
         ElapsedTime: {Scrubbed},
-        FinishTime: DateTimeOffset_4,
+        FinishTime: {Scrubbed},
         IncomingMessage: {
           TypeTag: StartSaga,
           Property: TheProperty
@@ -163,8 +163,8 @@
         ReplyToAddress: SerilogTestsStartSaga,
         Serilog.SagaStateChange: {Scrubbed},
         SourceContext: StartSaga,
-        StartTime: DateTimeOffset_5,
-        TimeSent: DateTimeOffset_2,
+        StartTime: {Scrubbed},
+        TimeSent: DateTimeOffset_1,
         TraceParent: {Scrubbed}
       }
     },

--- a/src/Tests/LogIncomingBehaviorTests.EmitsAuditOnSuccess.verified.txt
+++ b/src/Tests/LogIncomingBehaviorTests.EmitsAuditOnSuccess.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  target: {
+    Message: {
+      MessageType: LogIncomingBehaviorTests.Message1,
+      Instance: {}
+    },
+    MessageHandled: false,
+    MessageId: Guid_1,
+    ReplyToAddress: reply address,
+    Extensions: {
+      Serilog.ILogger: {},
+      SagaStateChangeRecorder: {
+        Value: 
+      }
+    }
+  },
+  log: {
+    Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+    Properties: {
+      ElapsedTime: {Scrubbed},
+      FinishTime: {Scrubbed},
+      IncomingMessage: {
+        TypeTag: Message1
+      },
+      StartTime: {Scrubbed}
+    }
+  }
+}

--- a/src/Tests/LogIncomingBehaviorTests.EmitsAuditWhenNextThrows.verified.txt
+++ b/src/Tests/LogIncomingBehaviorTests.EmitsAuditWhenNextThrows.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  target: {
+    Message: {
+      MessageType: LogIncomingBehaviorTests.Message1,
+      Instance: {}
+    },
+    MessageHandled: false,
+    MessageId: Guid_1,
+    ReplyToAddress: reply address,
+    Extensions: {
+      Serilog.ILogger: {},
+      SagaStateChangeRecorder: {
+        Value: 
+      }
+    }
+  },
+  log: {
+    Information: Receive message {IncomingMessageType} {IncomingMessageId} ({ElapsedTime:N3}s).,
+    Properties: {
+      ElapsedTime: {Scrubbed},
+      FinishTime: {Scrubbed},
+      IncomingMessage: {
+        TypeTag: Message1
+      },
+      StartTime: {Scrubbed}
+    }
+  }
+}

--- a/src/Tests/LogIncomingBehaviorTests.SkipsWhenInformationDisabled.verified.txt
+++ b/src/Tests/LogIncomingBehaviorTests.SkipsWhenInformationDisabled.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  Message: {
+    MessageType: LogIncomingBehaviorTests.Message1,
+    Instance: {}
+  },
+  MessageHandled: false,
+  MessageId: Guid_1,
+  ReplyToAddress: reply address,
+  Extensions: {
+    Serilog.ILogger: {}
+  }
+}

--- a/src/Tests/LogIncomingBehaviorTests.cs
+++ b/src/Tests/LogIncomingBehaviorTests.cs
@@ -1,0 +1,60 @@
+public class LogIncomingBehaviorTests
+{
+    [Test]
+    public async Task EmitsAuditOnSuccess()
+    {
+        var context = BuildContext();
+        context.Extensions.Set(Log.Logger);
+        Recording.Start();
+
+        await BuildBehavior().Invoke(context, () => Task.CompletedTask);
+
+        await Verify(context);
+    }
+
+    [Test]
+    public async Task EmitsAuditWhenNextThrows()
+    {
+        var context = BuildContext();
+        context.Extensions.Set(Log.Logger);
+        Recording.Start();
+
+        var caught = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            BuildBehavior().Invoke(context, () => throw new InvalidOperationException("boom")));
+
+        await Assert.That(caught!.Message).IsEqualTo("boom");
+        await Verify(context);
+    }
+
+    [Test]
+    public async Task SkipsWhenInformationDisabled()
+    {
+        var disabledLogger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .CreateLogger();
+        var context = BuildContext();
+        context.Extensions.Set((ILogger) disabledLogger);
+        Recording.Start();
+
+        var nextCalled = false;
+        await BuildBehavior().Invoke(context, () =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(nextCalled).IsTrue();
+        await Verify(context);
+    }
+
+    static TestableIncomingLogicalMessageContext BuildContext() =>
+        new()
+        {
+            Message = new(new(typeof(Message1)), new Message1())
+        };
+
+    static LogIncomingBehavior BuildBehavior() =>
+        new(convertHeader: (_, _) => null);
+
+    class Message1;
+}

--- a/src/Tests/SagaStateChangeRecorderTests.cs
+++ b/src/Tests/SagaStateChangeRecorderTests.cs
@@ -1,0 +1,29 @@
+public class SagaStateChangeRecorderTests
+{
+    [Test]
+    public async Task EmptyByDefault()
+    {
+        var recorder = new SagaStateChangeRecorder();
+        await Assert.That(recorder.Value).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SingleEntry()
+    {
+        var recorder = new SagaStateChangeRecorder();
+        var id = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        recorder.Record(id, "New");
+        await Assert.That(recorder.Value).IsEqualTo($"{id}:New");
+    }
+
+    [Test]
+    public async Task MultipleEntriesJoinedBySemicolon()
+    {
+        var recorder = new SagaStateChangeRecorder();
+        var id1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var id2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        recorder.Record(id1, "New");
+        recorder.Record(id2, "Updated");
+        await Assert.That(recorder.Value).IsEqualTo($"{id1}:New;{id2}:Updated");
+    }
+}

--- a/src/Tests/TestConfig/ModuleInitializer.cs
+++ b/src/Tests/TestConfig/ModuleInitializer.cs
@@ -28,7 +28,13 @@
                 "TraceParent",
                 "Task",
                 "TargetSite",
-                "baggage");
+                "baggage",
+                "StartTime",
+                "FinishTime",
+                "HandlerStartTime",
+                "HandlerFailureTime",
+                "Handler start time",
+                "Handler failure time");
 
         LogManager.Use<SerilogFactory>();
     }


### PR DESCRIPTION
LogIncomingBehavior
  - Wrap next() in try/finally so the audit log entry emits even when the handler throws. Previously failures bypassed the audit; the "Receive message" entries on retry paths in HandlerThatThrows / BehaviorThatThrows / Saga integration snapshots are the visible result.
  - Short-circuit when Information is disabled, skipping BindProperty destructuring, header enumeration, and LogEvent allocation. Matches CaptureSagaStateBehavior's existing gating. Comment flags the implicit coupling with WriteInfo's level.
  - Use Stopwatch.GetTimestamp / GetElapsedTime for ElapsedTime instead of DateTimeOffset.Now subtraction (NTP / DST safe). StartTime kept as DateTimeOffset.Now for display; FinishTime derived by addition.
  - Seed a SagaStateChangeRecorder into context.Extensions before next(); CaptureSagaStateBehavior mutates the same instance via TryGet. Emit its accumulated value as Serilog.SagaStateChange. Replaces the previous mechanism of mutating context.Headers to smuggle saga state forward across behaviors.
  - Constructor made internal so tests can construct directly.

  CaptureSagaStateBehavior
  - Same Stopwatch swap for ElapsedTime.
  - Saga state coordination moved from context.Headers mutation to the shared SagaStateChangeRecorder in context.Extensions.
  - IsEnabled gate comment added for consistency.

  Tests
  - New SagaStateChangeRecorder unit tests (empty / single / multi).
  - New LogIncomingBehavior tests using the project's standard Recording + Verify pattern: success, on-failure, and disabled-level short-circuit.
  - Integration snapshots regenerated to include the now-emitted audit entries on failure paths.
  - ModuleInitializer: scrub the timing members (StartTime, FinishTime, HandlerStartTime, HandlerFailureTime, Handler start time, Handler failure time) since the additional audit entries on retry paths multiplied the DateTimeOffset auto-numbering surface and caused occasional snapshot flakes when timestamps collided.
  - readme snippet link updated to the test's new line range.
